### PR TITLE
Heroku CI Support

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
+
+$BP_DIR/vendor/buildpack test $1 $2

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
+
+$BP_DIR/vendor/buildpack test-compile $1 $2 $3

--- a/buildpack/mrblib/buildpack/cli.rb
+++ b/buildpack/mrblib/buildpack/cli.rb
@@ -11,6 +11,8 @@ Usage:
   buildpack detect <build-dir>
   buildpack compile <build-dir> <cache-dir> <env-dir>
   buildpack release <build-dir>
+  buildpack test-compile <build-dir> <cache-dir> <env-dir>
+  buildpack test <build-dir> <env-dir>
   buildpack (-v | --version)
   buildpack (-h | --help)
 USAGE
@@ -33,6 +35,10 @@ USAGE
         Compile.new(@output_io, @error_io, @options["<build-dir>"], @options["<cache-dir>"], @options["<env-dir>"]).run
       elsif Release.detect(@options)
         Release.new(@output_io, @error_io, @options["<build-dir>"]).run
+      elsif TestCompile.detect(@options)
+        TestCompile.new(@output_io, @error_io, @options["<build-dir>"], @options["<cache-dir>"], @options["<env-dir>"]).run
+      elsif Test.detect(@options)
+        Test.new(@output_io, @error_io, @options["<build-dir>"], @options["<env-dir>"]).run
       else
         Help.new(@output_io, @error_io).run
       end

--- a/buildpack/mrblib/buildpack/commands/test.rb
+++ b/buildpack/mrblib/buildpack/commands/test.rb
@@ -1,0 +1,22 @@
+module Buildpack::Shell; end
+
+module Buildpack::Commands
+  class Test
+    include Shell
+
+    def self.detect(options)
+      options["test"]
+    end
+
+    def initialize(output_io, error_io, build_dir, env_dir)
+      @output_io = output_io
+      @error_io  = error_io
+      @build_dir = build_dir
+      @env_dir   = env_dir
+    end
+
+    def run
+      BuildpackRunner.new(@output_io, @error_io, "heroku/nodejs-v98").test(@build_dir, @env_dir)
+    end
+  end
+end

--- a/buildpack/mrblib/buildpack/commands/test_compile.rb
+++ b/buildpack/mrblib/buildpack/commands/test_compile.rb
@@ -1,0 +1,35 @@
+module Buildpack::Shell; end
+
+module Buildpack::Commands
+  class TestCompile
+    include Shell
+
+    def self.detect(options)
+      options["test-compile"]
+    end
+
+    def initialize(output_io, error_io, build_dir, cache_dir, env_dir)
+      @output_io = output_io
+      @error_io  = error_io
+      @build_dir = build_dir
+      @cache_dir = cache_dir
+      @env_dir   = env_dir
+    end
+
+    def run
+      buildpacks = %w(heroku/nodejs-v98 heroku/ember-cli-deploy)
+      mktmpdir("exports") do |dir|
+        buildpacks.inject([]) do |exports, name|
+          export      = BuildpackRunner.new(@output_io, @error_io, name).test_compile(@build_dir, @cache_dir, @env_dir, exports)
+          export_file = "#{dir}/#{name.split("/").last}"
+
+          File.open(export_file, "w") do |file|
+            file.puts export
+          end
+
+          exports + [export_file]
+        end
+      end
+    end
+  end
+end

--- a/buildpack/mrblib/buildpack/shell.rb
+++ b/buildpack/mrblib/buildpack/shell.rb
@@ -10,14 +10,24 @@ module Buildpack
       [output, $?]
     end
 
-    def pipe(command)
+    def pipe(command, output_io = @output_io)
       IO.popen(command) do |io|
         while data = io.read(1)
-          @output_io.print data
+          output_io.print data
         end
       end
 
       $?
+    end
+
+    def pipe_exit_on_error(command, output_io = @output_io, error_io = @error_io)
+      status = pipe(command, output_io)
+      if status.success?
+        status
+      else
+        error_io.puts "Error running: #{command}" if error_io
+        exit 1
+      end
     end
 
     def command_success?(command)


### PR DESCRIPTION
Runs the `bin/test-compile` from the nodejs and ember-cli-deploy buildpacks. `ember test` should be specified by default in `package.json`. For `bin/test`, the nodejs buildpack just executes `npm/yarn test`.