### PR TITLE
[changelog skip] Fix Escaping in Changelog Script

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -9,4 +9,4 @@ jobs:
    - uses: actions/checkout@v1
    - name: Check that CHANGELOG is touched
      run: |
-       cat $GITHUB_EVENT_PATH | jq .pull_request.title |  grep -i '[((changelog skip)|(ci skip))]' ||  git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md
+       cat $GITHUB_EVENT_PATH | jq .pull_request.title |  grep -i '\[\(\(changelog skip\)\|\(ci skip\)\)\]' ||  git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,7 +1,8 @@
 name: Check Changelog
 
-on: [pull_request]
-
+on:
+ pull_request:
+  types: [opened, reopened, edited, synchronize]
 jobs:
  build:
    runs-on: ubuntu-latest

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,0 +1,12 @@
+name: Check Changelog
+
+on: [pull_request]
+
+jobs:
+ build:
+   runs-on: ubuntu-latest
+   steps:
+   - uses: actions/checkout@v1
+   - name: Check that CHANGELOG is touched
+     run: |
+       cat $GITHUB_EVENT_PATH | jq .pull_request.title |  grep -i '[((changelog skip)|(ci skip))]' ||  git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md


### PR DESCRIPTION
The previous PR had a bug where the REGEX for grep was not properly escaped. This PR fixes that issue.