### PR TITLE
Get `rake compile` working

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
+export BUILDPACK_LOG_FILE=/dev/null
 
 $BP_DIR/vendor/buildpack compile $1 $2 $3

--- a/buildpack/build_config.rb
+++ b/buildpack/build_config.rb
@@ -5,11 +5,12 @@ def gem_config(conf)
   conf.gem File.expand_path(File.dirname(__FILE__))
   conf.gem core: 'mruby-sprintf'
   conf.gem core: 'mruby-time'
+  conf.gem core: 'mruby-print'
   conf.gem mgem: 'mruby-simple-random'
   conf.gem github: 'hone/mruby-io', branch: 'popen_status'
   conf.gem github: 'hone/mruby-process', branch: 'header'
   conf.gem github: 'mattn/mruby-onig-regexp', checksum_hash: '4873e87fc1842e8e2a417f6071b63a7d91523ef4'
-  conf.enable_cxx_abi
+  #conf.enable_cxx_abi
 end
 
 MRuby::Build.new do |conf|

--- a/buildpack/mrbgem.rake
+++ b/buildpack/mrbgem.rake
@@ -4,7 +4,6 @@ MRuby::Gem::Specification.new('buildpack') do |spec|
   spec.summary = 'buildpack'
   spec.bins    = ['buildpack']
 
-  spec.add_dependency 'mruby-docopt',            github:  'hone/mruby-docopt'
   spec.add_dependency 'mruby-env',               mgem:    'mruby-env'
   spec.add_dependency 'mruby-exit',              core:    'mruby-exit'
   spec.add_dependency 'mruby-fileutils-simple',  github:  'hone/mruby-fileutils-simple'
@@ -13,7 +12,7 @@ MRuby::Gem::Specification.new('buildpack') do |spec|
   spec.add_dependency 'mruby-json',              mgem:    'mruby-json'
   spec.add_dependency 'mruby-polarssl',          mgem:    'mruby-polarssl'
   spec.add_dependency 'mruby-tempfile',          mgem:    'mruby-tempfile'
-  spec.add_dependency 'mruby-yaml',              github:  'hone/mruby-yaml'
+  spec.add_dependency 'mruby-yaml',              mgem:    'mruby-yaml'
   spec.add_test_dependency 'mruby-mtest',        mgem:    'mruby-mtest'
   spec.add_test_dependency 'mruby-stringio',     mgem:    'mruby-stringio'
 end

--- a/buildpack/mrblib/buildpack/cli.rb
+++ b/buildpack/mrblib/buildpack/cli.rb
@@ -17,7 +17,7 @@ Usage:
   buildpack (-h | --help)
 USAGE
     def initialize(argv, output_io, error_io)
-      @options   = Docopt.parse(USAGE, argv)
+      @options    = ARGV
       @output_io = output_io.instance_eval do
         extend Buildpack::Messaging
       end
@@ -30,15 +30,15 @@ USAGE
       if Version.detect(@options)
         Version.new(@output_io, @error_io).run
       elsif Detect.detect(@options)
-        Detect.new(@output_io, @error_io, @options["<build-dir>"]).run
+        Detect.new(@output_io, @error_io, ARGV[2]).run
       elsif Compile.detect(@options)
-        Compile.new(@output_io, @error_io, @options["<build-dir>"], @options["<cache-dir>"], @options["<env-dir>"]).run
+        Compile.new(@output_io, @error_io, ARGV[2], ARGV[3], ARGV[4]).run
       elsif Release.detect(@options)
-        Release.new(@output_io, @error_io, @options["<build-dir>"]).run
+        Release.new(@output_io, @error_io, ARGV[2]).run
       elsif TestCompile.detect(@options)
-        TestCompile.new(@output_io, @error_io, @options["<build-dir>"], @options["<cache-dir>"], @options["<env-dir>"]).run
+        TestCompile.new(@output_io, @error_io, ARGV[2], ARGV[3], ARGV[4]).run
       elsif Test.detect(@options)
-        Test.new(@output_io, @error_io, @options["<build-dir>"], @options["<env-dir>"]).run
+        Test.new(@output_io, @error_io, ARGV[2], ARGV[3]).run
       else
         Help.new(@output_io, @error_io).run
       end

--- a/buildpack/mrblib/buildpack/commands/compile.rb
+++ b/buildpack/mrblib/buildpack/commands/compile.rb
@@ -7,7 +7,7 @@ module Buildpack::Commands
     STATIC_JSON = "package.json"
 
     def self.detect(options)
-      options["compile"]
+      options[1] == "compile"
     end
 
     def initialize(output_io, error_io, build_dir, cache_dir, env_dir)

--- a/buildpack/mrblib/buildpack/commands/detect.rb
+++ b/buildpack/mrblib/buildpack/commands/detect.rb
@@ -1,7 +1,7 @@
 module Buildpack::Commands
   class Detect
     def self.detect(options)
-      options["detect"]
+      options[1] == "detect"
     end
 
     def initialize(output_io, error_io, build_dir)

--- a/buildpack/mrblib/buildpack/commands/release.rb
+++ b/buildpack/mrblib/buildpack/commands/release.rb
@@ -3,7 +3,7 @@ module Buildpack::Commands
     FILE_PATH = "tmp/heroku-buildpack-release.yml"
 
     def self.detect(options)
-      options["release"]
+      options[1] == "release"
     end
 
     def initialize(output_io, error_io, build_dir)

--- a/buildpack/mrblib/buildpack/commands/test.rb
+++ b/buildpack/mrblib/buildpack/commands/test.rb
@@ -5,7 +5,7 @@ module Buildpack::Commands
     include Shell
 
     def self.detect(options)
-      options["test"]
+      options[1] == "test"
     end
 
     def initialize(output_io, error_io, build_dir, env_dir)

--- a/buildpack/mrblib/buildpack/commands/test_compile.rb
+++ b/buildpack/mrblib/buildpack/commands/test_compile.rb
@@ -5,7 +5,7 @@ module Buildpack::Commands
     include Shell
 
     def self.detect(options)
-      options["test-compile"]
+      options[1] == "test-compile"
     end
 
     def initialize(output_io, error_io, build_dir, cache_dir, env_dir)

--- a/buildpack/mrblib/buildpack/commands/version.rb
+++ b/buildpack/mrblib/buildpack/commands/version.rb
@@ -1,7 +1,7 @@
 module Buildpack::Commands
   class Version
     def self.detect(options)
-      options["--version"] || options["-v"]
+      options[1] == "--version" || options[1] == "-v"
     end
 
     def initialize(output_io, error_io)


### PR DESCRIPTION
This should be run on Ubuntu 16.04 (Xenial), otherwise a too new libc is required during a deploy to older stacks.

This should get things building again so that #61 can be addressed.