### PR TITLE
Switch instructions to using GitHub buildpack URL [changelog skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a [Heroku Buildpack](http://devcenter.heroku.com/articles/buildpacks) fo
 This buildpack has a binary component, so it needs to be compiled beforehand. It's easier just to use the buildpack with the prebuilt binary.
 
 ```
-$ heroku buildpacks:set https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz
+$ heroku buildpacks:set https://github.com/heroku/heroku-buildpack-emberjs.git
 ```
 
 Once the buildpack is set, you can `git push heroku master` like any other Heroku application.
@@ -21,7 +21,7 @@ Deploying a standard ember.js app on Heroku is simple. You can run the following
 
 ```
 $ heroku create
-$ heroku buildpacks:set https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz
+$ heroku buildpacks:set https://github.com/heroku/heroku-buildpack-emberjs.git
 $ git push heroku master
 $ heroku open
 ```
@@ -32,28 +32,10 @@ Deploying an ember fastboot on Heroku is just as simple. You can run the followi
 
 ```
 $ heroku create
-$ heroku buildpacks:set https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz
+$ heroku buildpacks:set https://github.com/heroku/heroku-buildpack-emberjs.git
 $ git push heroku master
 $ heroku open
 ```
-
-### Problems
-
-If you get an error setting the buildpack like the following:
-
-```
-$ heroku buildpacks:set https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz
-▸ Invalid buildpack `heroku/emberjs`
-```
-
-This means that `npm` is having issues keeping the core heroku toolbelt plugins up to date. To fix this you can run these commands:
-
-```
-$ rm -rf ~/.heroku/node_modules/heroku-apps
-$ heroku update
-```
-
-This causes the core plugins to be redownloaded with the latest version.
 
 ## Architecture
 


### PR DESCRIPTION
Since buildkits is deprecated, and the current published version is out of date (see #61). Whilst we can (and will likely) perform a one-off publish of `master` to buildkits, it's likely the version there will become out of date again in the future, so it's just easier to use GitHub URLs instead.

This buildpack also does not exist on buildpack registry.

Refs #61.